### PR TITLE
Fix shebang in scripts

### DIFF
--- a/examples/software_heritage_licenses/prepare_tlsh_hashes.py
+++ b/examples/software_heritage_licenses/prepare_tlsh_hashes.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # Copyright 2022 - Armijn Hemel
 # 

--- a/examples/software_heritage_licenses/test_licenses.py
+++ b/examples/software_heritage_licenses/test_licenses.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # Copyright 2022 - Armijn Hemel
 # 

--- a/examples/software_heritage_licenses/walk_software_heritage_blobs.py
+++ b/examples/software_heritage_licenses/walk_software_heritage_blobs.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # Copyright 2022 - Armijn Hemel
 # 

--- a/src/proximity_matcher_webservice/create_vpt_pickle.py
+++ b/src/proximity_matcher_webservice/create_vpt_pickle.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # Copyright 2022 - Armijn Hemel
 # 


### PR DESCRIPTION
While the current version also works, automated tools that parse the shebang like `patchShebangs` of nixpkgs need them to be in the form of `#!/path/to/executable` instead of `#/path/to/executable`.